### PR TITLE
feat(#3): add ExchangeRate.host provider integration

### DIFF
--- a/apps-gateway/nest-cli.json
+++ b/apps-gateway/nest-cli.json
@@ -3,6 +3,10 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [
+      { "include": "providers/specs/**/*.yaml", "outDir": "dist/src" }
+    ],
+    "watchAssets": true
   }
 }

--- a/apps-gateway/src/aggregate/aggregate.service.ts
+++ b/apps-gateway/src/aggregate/aggregate.service.ts
@@ -47,6 +47,11 @@ export class AggregateService {
         await import('../providers/transforms/restcountries.transform.js')
       ).normalizeRestCountries(body);
     }
+    if (id === 'exchange-rate') {
+      data = (
+        await import('../providers/transforms/exchange-rate.transform.js')
+      ).normalizeExchangeRate(body);
+    }
 
     await this.cache.set(key, data, spec.cache?.ttl ?? 60, true);
     return { id, data, cache: false };

--- a/apps-gateway/src/aggregate/dto/aggregate.dto.ts
+++ b/apps-gateway/src/aggregate/dto/aggregate.dto.ts
@@ -1,8 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+function toArray(val: unknown): string[] {
+  if (Array.isArray(val)) return val.map(String);
+  if (typeof val === 'string') {
+    return val
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
 
 export class AggregateQueryDto {
-  @ApiProperty({ example: ['weather.open-meteo', 'rest-countries'] })
+  @ApiProperty({
+    example: ['weather.open-meteo', 'rest-countries'],
+    type: [String],
+  })
+  @Transform(({ value }) => toArray(value))
   @IsArray()
   providers!: string[];
 

--- a/apps-gateway/src/providers/specs/exchange-rate.yaml
+++ b/apps-gateway/src/providers/specs/exchange-rate.yaml
@@ -1,0 +1,8 @@
+id: exchange-rate
+baseUrl: https://api.exchangerate.host
+endpoint: /latest
+query:
+  base: string
+  symbols: string
+cache:
+  ttl: 600

--- a/apps-gateway/src/providers/transforms/exchange-rate.transform.ts
+++ b/apps-gateway/src/providers/transforms/exchange-rate.transform.ts
@@ -1,0 +1,9 @@
+export function normalizeExchangeRate(res: any) {
+  return {
+    source: 'exchange-rate',
+    at: new Date().toISOString(),
+    base: res?.base,
+    date: res?.date,
+    rates: res?.rates ?? {},
+  };
+}


### PR DESCRIPTION
### Summary
Adds ExchangeRate.host provider for currency data.

### Testing
- `/aggregate?providers=exchange-rate&params={"base":"USD","symbols":"EUR,GBP"}`
returns live rates.

### Linked Issue
Closes #3 
