### PR TITLE
feat(#5): add OpenAQ provider (+normalize)

### DIFF
--- a/apps-gateway/src/aggregate/aggregate.service.ts
+++ b/apps-gateway/src/aggregate/aggregate.service.ts
@@ -52,6 +52,11 @@ export class AggregateService {
         await import('../providers/transforms/exchange-rate.transform.js')
       ).normalizeExchangeRate(body);
     }
+    if (id === 'openaq') {
+      data = (
+        await import('../providers/transforms/openaq.transform.js')
+      ).normalizeOpenAQ(body);
+    }
 
     await this.cache.set(key, data, spec.cache?.ttl ?? 60, true);
     return { id, data, cache: false };

--- a/apps-gateway/src/providers/specs/openaq.yaml
+++ b/apps-gateway/src/providers/specs/openaq.yaml
@@ -1,0 +1,9 @@
+id: openaq
+baseUrl: https://api.openaq.org
+endpoint: /v2/latest
+query:
+  country: string # ISO-2 code, e.g. XK
+  city: string # e.g. Pristina
+  limit: number # default 1
+cache:
+  ttl: 600

--- a/apps-gateway/src/providers/transforms/openaq.transform.ts
+++ b/apps-gateway/src/providers/transforms/openaq.transform.ts
@@ -1,0 +1,25 @@
+export function normalizeOpenAQ(res: any) {
+  const result = res?.results?.[0] ?? {};
+  const measurements = result?.measurements ?? [];
+
+  // Build a quick lookup by parameter name (lowercased)
+  const byParam = Object.fromEntries(
+    measurements.map((m: any) => [
+      String(m?.parameter ?? '').toLowerCase(),
+      m?.value,
+    ]),
+  );
+
+  return {
+    source: 'openaq',
+    at: new Date().toISOString(),
+    // Common pollutants; values are typically in µg/m³
+    pm25: byParam['pm25'] ?? null,
+    pm10: byParam['pm10'] ?? null,
+    no2: byParam['no2'] ?? null,
+    o3: byParam['o3'] ?? null,
+    so2: byParam['so2'] ?? null,
+    // optional raw for debugging
+    // raw: res
+  };
+}


### PR DESCRIPTION
### Summary
Adds OpenAQ provider and normalization.

### Testing
- `/aggregate?providers=openaq&params={"country":"XK","city":"Pristina","limit":1}`

### Linked Issue
Closes #5 
